### PR TITLE
hardcode slack channel

### DIFF
--- a/app/models/slack.rb
+++ b/app/models/slack.rb
@@ -18,7 +18,7 @@ class Slack
     # This is the old way of posting to slack on behalf of a user using a webhook.
     # https://api.slack.com/legacy/custom-integrations/messaging/webhooks
     # It might be necessary to change this in the future to use the new Slack API.
-    request_hook url: Config.slack_webhook_url!, body: personalized_webhook_body(user:, message:).to_json
+    request_hook url: Config.slack_webhook_url!, body: personalized_webhook_body(user:, message:, channel: "the-daily-nerd").to_json
   end
 
   def retrieve_users_slack_id_by_email(email)
@@ -57,8 +57,9 @@ class Slack
     response
   end
 
-  def personalized_webhook_body(user:, message:)
+  def personalized_webhook_body(user:, message:, channel:)
     {
+      channel:,
       username: user.display_name,
       icon_url: user.slack_profile.image_url,
       text: message


### PR DESCRIPTION
fixes #92 

Don't use a different channel for development, like that we don't need any env vars.

as discussed in:
https://nerdgeschoss.slack.com/archives/C050UHVKLD8/p1714037244575979