### PR TITLE
Fix: Run `db:prepare` for Review App

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "addons": ["newrelic", "heroku-postgresql", "heroku-redis"],
+  "addons": ["newrelic", "heroku-postgresql:essential-0", "heroku-redis"],
   "buildpacks": [
     {
       "url": "https://github.com/brandoncc/heroku-buildpack-vips.git"
@@ -26,7 +26,7 @@
   },
   "name": "nerdgeschoss_app",
   "scripts": {
-    "postdeploy": "bin/rails db:seed"
+    "postdeploy": "bin/rails db:prepare"
   },
   "stack": "heroku-20"
 }


### PR DESCRIPTION
Currently, the seeds are not loaded correctly because we're not migrated yet:

<img width="559" alt="image" src="https://github.com/nerdgeschoss/app/assets/2098462/4d4d0e2d-e621-4b20-9735-5aedd44ed2fb">

The `db:prepare` task seems pretty good for ensuring we have a working setup:

https://edgeguides.rubyonrails.org/active_record_migrations.html#preparing-the-database