### PR TITLE
Make sprint retros work for admins

### DIFF
--- a/app/assets/stylesheets/application/components/feedback.scss
+++ b/app/assets/stylesheets/application/components/feedback.scss
@@ -42,19 +42,19 @@
     gap: 4px;
 
     &:has([value='1']:checked) {
-      --emoji: '😖';
-    }
-    &:has([value='2']:checked) {
       --emoji: '😔';
     }
-    &:has([value='3']:checked) {
+    &:has([value='2']:checked) {
       --emoji: '😐';
     }
-    &:has([value='4']:checked) {
+    &:has([value='3']:checked) {
       --emoji: '🙂';
     }
-    &:has([value='5']:checked) {
+    &:has([value='4']:checked) {
       --emoji: '😊';
+    }
+    &:has([value='5']:checked) {
+      --emoji: '🥳';
     }
   }
 

--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -92,8 +92,4 @@ class Sprint < ApplicationRecord
 
     ratings.sum / ratings.size.to_f
   end
-
-  def to_be_rated?
-    sprint_until.today? || completed?
-  end
 end

--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -31,7 +31,7 @@ class Sprint < ApplicationRecord
   range_accessor_methods :sprint
 
   def full_title
-    "#{title} (#{ApplicationController.helpers.date_range(sprint_during.min, sprint_during.max, format: :long)})"
+    "#{title} (#{ApplicationController.helpers.date_range(sprint_from, sprint_until, format: :long)})"
   end
 
   def total_working_days

--- a/app/models/sprint_feedback.rb
+++ b/app/models/sprint_feedback.rb
@@ -87,6 +87,10 @@ class SprintFeedback < ApplicationRecord
     has_retro? || skip_retro?
   end
 
+  def by?(user)
+    self.user == user
+  end
+
   def recalculate_costs
     salary = user.salary_at(sprint.sprint_from)
     return unless salary

--- a/app/policies/sprint_feedback_policy.rb
+++ b/app/policies/sprint_feedback_policy.rb
@@ -27,7 +27,7 @@ class SprintFeedbackPolicy < ApplicationPolicy
 
   def permitted_attributes
     if hr?
-      [:daily_nerd_count, :tracked_hours, :billable_hours, :review_notes, :skip_retro]
+      [:daily_nerd_count, :tracked_hours, :billable_hours, :review_notes, :retro_rating, :retro_text, :skip_retro]
     else
       [:retro_rating, :retro_text, :skip_retro]
     end

--- a/app/views/sprints/_sprint.html.slim
+++ b/app/views/sprints/_sprint.html.slim
@@ -67,32 +67,36 @@
                 div title="Costs" = number_to_currency -sprint.costs
                 div title="Revenue" = number_to_currency sprint.revenue
 
-      - if sprint.to_be_rated?
-        - feedbacks = sprint.sprint_feedbacks.select { _1.has_retro? || _1.user == @user }
-        .feedback.stack
-          .feedback__heading = t(".feedback") if feedbacks.any?
+      - feedbacks = sprint.sprint_feedbacks.select { _1.has_retro? || policy(_1).update? }
+      .feedback.stack
+        .feedback__heading = t(".feedback") if feedbacks.any?
 
-          - feedbacks.each do |feedback|
-            - is_own = feedback.user == @user
-            .feedback__item.stack.stack--row(data-controller=(is_own && "feedback"))
-              .feedback__column
-                - if feedback.has_retro?
-                  .feedback__content(data-feedback-target="content")
-                    strong = t(".user_feedback", user: feedback.user.display_name, rating: feedback.retro_rating)
-                    = markdown feedback.retro_text
-                - elsif feedback.skip_retro?
-                  .feedback__content(data-feedback-target="content")
-                    strong = t(".user_skipped_retro", user: feedback.user.display_name)
-                - else
-                  .feedback__alert = t(".please_write_feedback")
+        - feedbacks.each do |feedback|
+          - display_name = feedback.user.display_name
+          - can_edit = policy(feedback).update?
+          - show_content = feedback.retro_completed? || !feedback.by?(current_user)
 
-                - if is_own
-                  .feedback__form(data-feedback-target="form" class=(feedback.retro_completed? && "feedback__form--hidden"))
-                    .feedback__form-heading = t('.edit_feedback')
-                    = render "sprint_feedbacks/edit_retro", feedback:
+          .feedback__item.stack.stack--row(data-controller=(can_edit && "feedback"))
+            .feedback__column
+              - if show_content
+                .feedback__content(data-feedback-target="content")
+                  - if feedback.has_retro?
+                      strong = t(".user_feedback", user: display_name, rating: feedback.retro_rating)
+                      = markdown feedback.retro_text
+                  - elsif feedback.skip_retro?
+                      strong = t(".user_skipped_retro", user: display_name)
+                  - elsif !feedback.by?(current_user)
+                      strong = t(".user_feedback_missing", user: display_name)
+              - elsif feedback.by?(current_user)
+                .feedback__alert = t(".please_write_feedback")
 
-              - if is_own && feedback.retro_completed?
-                button.button.button--small(data-action="feedback#toggle") Edit
+              - if can_edit
+                .feedback__form(data-feedback-target="form" class=class_names("feedback__form--hidden": feedback.retro_completed? || !feedback.by?(current_user) ))
+                  .feedback__form-heading = t('.edit_feedback', user: display_name)
+                  = render "sprint_feedbacks/edit_retro", feedback:
+
+            - if can_edit && show_content
+              button.button.button--small(data-action="feedback#toggle") Edit
 
   - if addable_users.any? && policy(SprintFeedback).create?
     .card__buttons

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,7 +91,7 @@ en:
     sprint:
       billable: Billable
       daily_nerd: Daily nerd
-      edit_feedback: Edit Feedback
+      edit_feedback: Edit Feedback (%{user})
       feedback: Feedback
       finished_storypoints: Finished storypoints
       please_write_feedback: Please write your feedback!
@@ -100,6 +100,7 @@ en:
       tracked: Tracked
       turnover: Turnover
       user_feedback: "%{user} rated: %{rating} / 5"
+      user_feedback_missing: "%{user} did not add their rating yet"
       user_skipped_retro: "%{user} skipped the retro"
   time_will_tell:
     date_range:

--- a/spec/fixtures/sprint_feedbacks.yml
+++ b/spec/fixtures/sprint_feedbacks.yml
@@ -16,7 +16,7 @@
 #  turnover               :decimal(, )
 #  costs                  :decimal(, )
 #
-sprint_feedback_1:
+sprint_feedback_john:
   sprint: empty
   user: john
   daily_nerd_count: 3
@@ -43,22 +43,18 @@ sprint_feedback_2:
     - 2023-01-25
   finished_storypoints: 5
 
-john_before:
-  sprint: before
-  user: john
-
-cigdem_before:
-  sprint: before
+cigdem_current:
+  sprint: empty
   user: cigdem
   retro_rating: 3
 
-yuki_before:
-  sprint: before
+yuki_current:
+  sprint: empty
   user: yuki
   retro_rating: 5
   retro_text: 'I liked the sprint'
 
-zacharias_before:
-  sprint: before
+zacharias_current:
+  sprint: empty
   user: zacharias
   skip_retro: true

--- a/spec/fixtures/sprints.yml
+++ b/spec/fixtures/sprints.yml
@@ -13,8 +13,3 @@ empty:
   title: S2023-02
   sprint_during: '[2023-01-23, 2023-02-03]'
   working_days: 10
-
-before:
-  title: S2023-before
-  sprint_during: '[2023-01-09, 2023-01-23]'
-  working_days: 10

--- a/spec/models/sprint_feedback_spec.rb
+++ b/spec/models/sprint_feedback_spec.rb
@@ -23,7 +23,7 @@ require "rails_helper"
 
 RSpec.describe SprintFeedback do
   fixtures :all
-  let(:feedback) { sprint_feedbacks(:sprint_feedback_1) }
+  let(:feedback) { sprint_feedbacks(:sprint_feedback_john) }
 
   context "when calculating costs" do
     it "calculates the costs based on the current salary" do

--- a/spec/models/sprint_spec.rb
+++ b/spec/models/sprint_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Sprint do
 
   describe "#average_rating" do
     it "returns the average sprint rating" do
-      sprint = sprints(:before)
+      sprint = sprints(:empty)
 
       expect(sprint.average_rating).to eq 4.0
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Task do
     end
 
     it "only updates finished_storypoints" do
-      sprint_feedback = sprint_feedbacks(:sprint_feedback_1)
+      sprint_feedback = sprint_feedbacks(:sprint_feedback_john)
       expect(sprint_feedback).to have_attributes finished_storypoints: 8
 
       Task.sync_with_github

--- a/spec/system/sprint_feedbacks_spec.rb
+++ b/spec/system/sprint_feedbacks_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Sprint Feedback" do
   fixtures :all
 
   before do
-    travel_to "2023-02-02"
+    travel_to "2023-02-05"
     login :john
   end
 
@@ -30,7 +30,7 @@ RSpec.describe "Sprint Feedback" do
   end
 
   it "allows editing the retro feedback" do
-    feedback = sprint_feedbacks(:john_before)
+    feedback = sprint_feedbacks(:sprint_feedback_john)
     feedback.update!(retro_text: "I'm happy!", retro_rating: 5)
     visit sprints_path
 


### PR DESCRIPTION
Fixes #35. (Again!)

- HR can now change ALL the retro data (so that Jens can backfill old retros), including their own (Wow!)
- Every user can add retros for every sprint – especially the one that is ongoing. We no longer check if it is "almost done".

## Review Notes

Review App: https://nerdgeschoss-feature-35-vgri4d.herokuapp.com/

Login in with `admin@nerdgeschoss.de` / `password`.

As admin, you can now see and edit all the sprint feedbacks:

<img width="853" alt="image" src="https://github.com/user-attachments/assets/a48dce2a-5f39-4bee-a3b7-8ecd3772d182">
