### PR TITLE
Use ubuntu-24.04 in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   ruby:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       postgres:


### PR DESCRIPTION
The `ubuntu-20.04` runner will soon be deprecated, because `ubuntu-24.04` will be made the default and `ubuntu-22.04` will be the "other" version: https://github.com/actions/runner-images/issues/10636

> Images begin the deprecation process of the oldest image label once a new GA OS version has been released.

Since this project (at least on staging, I can't see production) is already on Heroku-22, it should be no problem to run our CI against Ubuntu 22.