### PR TITLE
Remove Working Days from Sprint Creation Modal

### DIFF
--- a/app/views/sprints/new.props.rb
+++ b/app/views/sprints/new.props.rb
@@ -3,5 +3,4 @@
 field :sprint, value: -> { @sprint } do
   field :sprint_from, Time
   field :sprint_until, Time
-  field :working_days, Integer
 end

--- a/app/views/sprints/new.tsx
+++ b/app/views/sprints/new.tsx
@@ -8,7 +8,6 @@ import { TextField } from '../../frontend/components/text_field/text_field';
 import { DateField } from '../../frontend/components/date_field/date_field';
 import { useReaction } from '../../frontend/sprinkles/reaction';
 import { useModalInfo } from '../../frontend/components/modal/modal';
-import { NumberField } from '../../frontend/components/number_field/number_field';
 import { Form } from '../../frontend/components/form/form';
 import { handleError } from '../../frontend/util/errors';
 import { Box } from '../../frontend/components/box/box';
@@ -25,13 +24,11 @@ export default function ({
       title: '',
       sprintFrom: l.parseRequiredDate(sprint.sprintFrom),
       sprintUntil: l.parseRequiredDate(sprint.sprintUntil),
-      workingDays: sprint.workingDays,
     },
     validations: {
       title: 'required',
       sprintFrom: 'required',
       sprintUntil: 'required',
-      workingDays: 'required',
     },
     onSubmit: async ({ model }) => {
       await reaction.call({
@@ -57,10 +54,6 @@ export default function ({
           <DateField
             {...fields.sprintUntil}
             label={t('sprints.new.sprint_until')}
-          />
-          <NumberField
-            {...fields.workingDays}
-            label={t('sprints.new.working_days')}
           />
           <Button
             title={t('sprints.new.save')}

--- a/data.d.ts
+++ b/data.d.ts
@@ -301,7 +301,6 @@ export interface DataSchema {
     sprint: {
       sprintFrom: string;
       sprintUntil: string;
-      workingDays: number;
     };
   };
   'users/index': {


### PR DESCRIPTION
Fixes #171.

This was discovered in the Review Meeting. PR #172 accidentally kept the NumberInput for the Sprint Creation modal:

<img width="1356" height="860" alt="image" src="https://github.com/user-attachments/assets/dfb3de2f-49ae-4c4b-a81d-d1ddedf1ec32" />

<br>

Since this value is ignored now, we can leave it out:

<img width="671" height="331" alt="image" src="https://github.com/user-attachments/assets/b069e536-e8d7-4b91-bb8d-599b8552eff8" />
