### PR TITLE
Downgrade `mission_control-jobs`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "icalendar", "~> 2.4"
 gem "image_processing"
 gem "kaminari"
 gem "mini_magick"
-gem "mission_control-jobs"
+gem "mission_control-jobs", "=0.6.0" # NOTE: Keep this gem at this version for now as the newest version requires more work to get working.
 gem "pundit"
 gem "rails-i18n"
 gem "shimmer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    mission_control-jobs (1.1.0)
+    mission_control-jobs (0.6.0)
       actioncable (>= 7.1)
       actionpack (>= 7.1)
       activejob (>= 7.1)
@@ -648,7 +648,7 @@ DEPENDENCIES
   letter_opener
   listen
   mini_magick
-  mission_control-jobs
+  mission_control-jobs (= 0.6.0)
   newrelic_rpm
   oj
   pg
@@ -795,7 +795,7 @@ CHECKSUMS
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  mission_control-jobs (1.1.0) sha256=b13da9cde3344fec7c744b79d2a34c3ecd454f45d4d593d4c968ba762315e84c
+  mission_control-jobs (0.6.0) sha256=a9fabc12cc030c58b1c60d4b893a872c899933c87509667fec47ff9ea6ab8bc9
   msgpack (1.8.1) sha256=3fef787cd3965fd119c08a22724a56a93ca25008c3421fc15039f603a8b7c86c
   multi_xml (0.9.1) sha256=7ce766b59c17241ed62976caeae1fae9b2431b263398c35396239a68c4a64e57
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8


### PR DESCRIPTION
With #180, we also upgrade `mission_control-jobs`. Since https://github.com/rails/mission_control-jobs/pull/214, the mission control controller is locked down with HTTP basic authentication by default which requires additional configuration. Alternatively, we could change the controller that mission control inherits from to implement our own authentication logic. For now, a downgrade seems more suitable to me to get the control panel back.