### PR TITLE
Turbo

### DIFF
--- a/app/frontend/controllers/reaction_controller.tsx
+++ b/app/frontend/controllers/reaction_controller.tsx
@@ -1,0 +1,40 @@
+import { Controller } from '@hotwired/stimulus';
+import { createRoot, Root } from 'react-dom/client';
+import { reaction, ReactionContext } from '../sprinkles/reaction';
+import { Frame } from '../sprinkles/frame';
+import { Layout } from '../layout';
+import { Meta } from '../sprinkles/meta';
+
+export default class ReactionController extends Controller<HTMLElement> {
+  static targets = ['data', 'root'];
+  declare readonly dataTarget: HTMLTemplateElement;
+  declare readonly rootTarget: HTMLElement;
+  private root: Root | null = null;
+
+  connect(): void {
+    // Turbo preview snapshots already contain the last-rendered HTML; the
+    // controller connects again once the fresh body arrives.
+    if (document.documentElement.hasAttribute('data-turbo-preview')) return;
+    const raw = this.dataTarget.content.textContent;
+    const meta = new Meta(raw ? JSON.parse(decodeURIComponent(raw)) : {});
+    // the server strips the query string from the path; key the cache by the real URL
+    const url = window.location.pathname + window.location.search;
+    meta.path = url;
+    reaction.history.cache.clear();
+    reaction.history.cache.write(meta);
+    document.body.classList.remove('with-modal');
+    this.root = createRoot(this.rootTarget);
+    this.root.render(
+      <ReactionContext.Provider value={reaction}>
+        <Layout>
+          <Frame url={url} />
+        </Layout>
+      </ReactionContext.Provider>
+    );
+  }
+
+  disconnect(): void {
+    this.root?.unmount();
+    this.root = null;
+  }
+}

--- a/app/frontend/entrypoints/application.ts
+++ b/app/frontend/entrypoints/application.ts
@@ -1,6 +1,10 @@
-import { Layout } from '../layout';
-import { Reaction } from '../sprinkles/reaction';
+import '@hotwired/turbo-rails';
+import { Application } from '@hotwired/stimulus';
+import { registerControllers } from 'stimulus-vite-helpers';
 import '../components/reset.scss';
 
-const reaction = new Reaction({ layout: Layout });
-reaction.start();
+const application = Application.start();
+registerControllers(
+  application,
+  import.meta.glob('../controllers/**/*_controller.{ts,tsx}', { eager: true })
+);

--- a/app/frontend/sprinkles/history.tsx
+++ b/app/frontend/sprinkles/history.tsx
@@ -1,27 +1,12 @@
-import { JSX, ReactNode, useEffect, useState } from 'react';
+import { JSX, ReactNode } from 'react';
+import { Turbo } from '@hotwired/turbo-rails';
 import { Meta } from './meta';
-import { MetaCache, MetaCacheSubscription } from './meta_cache';
-import { useReaction } from './reaction';
-
-declare global {
-  interface Window {
-    data?: Record<string, unknown>;
-  }
-}
+import { MetaCache } from './meta_cache';
 
 export function usePath(): string {
-  const history = useReaction().history;
-  const [path, setPath] = useState(history.path);
-  useEffect(() => {
-    const listener = (history: History) => {
-      setPath(history.path);
-    };
-    history.subscribe(listener);
-    return () => {
-      history.unsubscribe(listener);
-    };
-  }, [history]);
-  return path;
+  // the React tree remounts on every Turbo visit, so the location at render
+  // time is always current
+  return window.location.pathname + window.location.search;
 }
 
 export function Link({
@@ -35,17 +20,8 @@ export function Link({
   children: ReactNode;
   className?: string;
 }): JSX.Element {
-  const history = useReaction().history;
   return (
-    <a
-      id={id}
-      href={href}
-      onClick={(event) => {
-        event.preventDefault();
-        history.navigate(href);
-      }}
-      className={className}
-    >
+    <a id={id} href={href} className={className}>
       {children}
     </a>
   );
@@ -53,35 +29,13 @@ export function Link({
 
 export class History {
   cache = new MetaCache();
-  path: string = window.location.pathname + window.location.search;
-  listeners: Array<(history: History) => void> = [];
-  private currentDataSubscription: MetaCacheSubscription | null = null;
 
-  constructor(private onChange: (meta: Meta) => void) {
-    window.addEventListener('popstate', this.restore.bind(this));
-    this.trackCurrentData();
+  get path(): string {
+    return window.location.pathname + window.location.search;
   }
 
-  private trackCurrentData(): void {
-    this.currentDataSubscription?.unsubscribe();
-    window.data = this.cache.peek(this.path)?.props;
-    this.currentDataSubscription = this.cache.subscribe(this.path, (props) => {
-      window.data = props as Record<string, unknown> | undefined;
-    });
-  }
-
-  async navigate(
-    url: string,
-    { allowStale = false }: { allowStale?: boolean } = {}
-  ): Promise<void> {
-    const result = await this.cache.fetch(url);
-    window.history.pushState({}, '', url);
-    this.path = url;
-    this.trackCurrentData();
-    this.onChange(result.meta);
-    if (result.fresh || allowStale) return;
-    this.onChange(await this.cache.refresh(url));
-    this.listeners.forEach((e) => e(this));
+  async navigate(url: string): Promise<void> {
+    Turbo.visit(url);
   }
 
   async refreshPageContent(): Promise<void> {
@@ -110,21 +64,5 @@ export class History {
         nextPageUrl: (page.props as { nextPageUrl: string }).nextPageUrl,
       },
     }));
-  }
-
-  async restore(): Promise<void> {
-    const url = window.location.pathname + window.location.search;
-    const result = await this.cache.fetch(url);
-    this.path = url;
-    this.trackCurrentData();
-    this.onChange(result.meta);
-  }
-
-  subscribe(listener: (history: History) => void): void {
-    this.listeners.push(listener);
-  }
-
-  unsubscribe(listener: (history: History) => void): void {
-    this.listeners = this.listeners.filter((e) => e !== listener);
   }
 }

--- a/app/frontend/sprinkles/reaction.ts
+++ b/app/frontend/sprinkles/reaction.ts
@@ -1,12 +1,11 @@
-import React, { createContext, FunctionComponent, ReactElement } from 'react';
-import { createRoot } from 'react-dom/client';
-import { Frame } from './frame';
+import React, { createContext, FunctionComponent } from 'react';
+import { Turbo } from '@hotwired/turbo-rails';
 import { History } from './history';
 import { Meta } from './meta';
 
 const imports = import.meta.glob('../../views/**/*.tsx', {});
 
-const ReactionContext = createContext<Reaction | null>(null);
+export const ReactionContext = createContext<Reaction | null>(null);
 export const useReaction = (): Reaction => {
   const reaction = React.useContext(ReactionContext);
   if (!reaction) throw new Error('ReactionContext not found');
@@ -14,21 +13,7 @@ export const useReaction = (): Reaction => {
 };
 
 export class Reaction {
-  private root!: ReturnType<typeof createRoot>;
-  private layout?: FunctionComponent<{
-    children: ReactElement;
-  }>;
-  history = new History((meta) => this.renderPage(meta.path));
-
-  constructor({ layout }: { layout?: Reaction['layout'] } | undefined = {}) {
-    this.layout = layout;
-  }
-
-  start(): void {
-    document.addEventListener('DOMContentLoaded', () => {
-      this.loadPage();
-    });
-  }
+  history = new History();
 
   async componentFor(path: string): Promise<FunctionComponent<unknown> | null> {
     const importPath = '../../views/' + path + '.tsx';
@@ -74,10 +59,15 @@ export class Reaction {
     if (response.headers.get('Content-Type')?.includes('application/json')) {
       const data = await response.json();
       if (data.component) {
+        // response.url is the final URL after redirects (the server-provided
+        // path loses its query string)
+        const landedUrl = new URL(response.url);
+        const landed = landedUrl.pathname + landedUrl.search;
         const meta = new Meta(data);
+        meta.path = landed;
         this.history.cache.write(meta);
-        if (data.path !== this.history.path) {
-          await this.history.navigate(data.path, { allowStale: true });
+        if (landed !== this.history.path) {
+          Turbo.visit(landed);
         }
       }
     }
@@ -85,35 +75,9 @@ export class Reaction {
       await this.history.refreshPageContent();
     }
   }
-
-  private async loadPage(): Promise<void> {
-    const rootElement = document.getElementById('root');
-    if (!rootElement) throw new Error('Root element not found');
-    const metaJson = (
-      document.querySelector(
-        'template[id="reaction-data"]'
-      ) as HTMLTemplateElement
-    ).content.textContent;
-    const data = metaJson ? JSON.parse(decodeURIComponent(metaJson)) : {};
-    const meta = new Meta(data);
-    meta.path = window.location.pathname + window.location.search;
-    this.history.cache.write(meta);
-    this.root = createRoot(rootElement);
-    this.renderPage(meta.path);
-  }
-
-  private async renderPage(path: string): Promise<void> {
-    const content = React.createElement(Frame, { url: path });
-    const app = React.createElement(
-      this.layout || React.Fragment,
-      undefined,
-      content
-    );
-    this.root.render(
-      React.createElement(ReactionContext.Provider, { value: this }, app)
-    );
-  }
 }
+
+export const reaction = new Reaction();
 
 function serialize(
   obj: object,

--- a/app/views/components/_head.html.slim
+++ b/app/views/components/_head.html.slim
@@ -7,6 +7,7 @@ head
   link rel="manifest" href=manifest_path
   link rel="apple-touch-icon" href=vite_asset_path("images/app-icon.png")
   meta name="theme-color" content="#ffffff"
+  meta name="turbo-prefetch" content="false"
   / SEO
   = favicon_link_tag vite_asset_path('images/app-icon.png')
 
@@ -17,6 +18,6 @@ head
   / Assets
   = vite_client_tag
   = vite_react_refresh_tag
-  = vite_typescript_tag "application"
+  = vite_typescript_tag "application", "data-turbo-track": "reload"
 
   = yield :additional_head_tags if content_for? :additional_head_tags

--- a/lib/reaction/controller.rb
+++ b/lib/reaction/controller.rb
@@ -24,14 +24,6 @@ module Reaction
         end
       end
 
-      def refresh_component_state(component)
-        render json: Response.new(component:, context: self).to_s
-      end
-
-      def refresh_page
-        render json: {refresh: true}
-      end
-
       def reaction_request?
         request.headers["X-Reaction"].present?
       end

--- a/lib/reaction/tsx_handler.rb
+++ b/lib/reaction/tsx_handler.rb
@@ -7,8 +7,10 @@ module Reaction
         id = Pathname.new(path).relative_path_from(Rails.root.join("app/views")).to_s.sub(".tsx", "")
         response = Response.new(component: id, context:)
         <<~HTML
-          <div id="root"></div>
-          <template id="reaction-data" style="display: none;">#{ERB::Util.url_encode(response.to_s)}</template>
+          <div data-controller="reaction">
+            <template data-reaction-target="data" style="display: none;">#{ERB::Util.url_encode(response.to_s)}</template>
+            <div data-reaction-target="root"></div>
+          </div>
         HTML
       end
     end

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@hotwired/stimulus": "^3.2.2",
+    "@hotwired/turbo-rails": "^8.0.23",
     "@nerdgeschoss/react-use-form-library": "^0.0.71",
     "@nerdgeschoss/shimmer-component-collapse": "^0.1.0",
     "@nerdgeschoss/shimmer-component-stack": "^0.1.0",
@@ -19,6 +21,7 @@
     "react-dom": "^19.0.0",
     "react-flatpickr": "^4.0.11",
     "sass": "^1.83.1",
+    "stimulus-vite-helpers": "^3.1.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.0",
     "vite-plugin-rails": "^0.6.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
   "files": ["typings.d.ts", "data.d.ts"],
   "include": [
     "app/javascript/**/*",
+    "app/frontend/controllers",
+    "app/frontend/entrypoints",
     "app/frontend/sprinkles",
     "app/frontend/util",
     "app/frontend/layout.tsx",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="vite/client" />
-declare module '@hotwired/stimulus' {
-  export const Controller: any;
-  export const Application: any;
+declare module '@hotwired/turbo-rails' {
+  export const Turbo: {
+    visit(
+      location: string,
+      options?: { action?: 'advance' | 'replace' | 'restore'; frame?: string }
+    ): void;
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,6 +216,24 @@
     "@eslint/core" "^1.2.1"
     levn "^0.4.1"
 
+"@hotwired/stimulus@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
+  integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
+
+"@hotwired/turbo-rails@^8.0.23":
+  version "8.0.23"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.23.tgz#7a84ad041cb0f3e5d9ff97d1a1f0291550a93fc9"
+  integrity sha512-iBILwda3qmQC7FYM70+4s6kEQ7Fx9dJ6+yGxjPyrz9a5JDx1+y7OAA5TA7GGVOZJoicMLrKGdFDNorl40X35lw==
+  dependencies:
+    "@hotwired/turbo" "^8.0.23"
+    "@rails/actioncable" ">=7.0"
+
+"@hotwired/turbo@^8.0.23":
+  version "8.0.23"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.23.tgz#a6eebc9ab4a5faadae265a4cbec8cfcb5731e77c"
+  integrity sha512-GZ7cijxEZ6Ig71u7rD6LHaRv/wcE/hNsc+nEfiWOkLNqUgLOwo5MNGWOy5ZV9ZUDSiQx1no7YxjTNnT4O6//cQ==
+
 "@humanfs/core@^0.19.2":
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.2.tgz#a8272ca03b2acf492670222b2320b6c421bfde60"
@@ -401,6 +419,11 @@
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.3.6.tgz#3569708bd4be4d8870ba32bf1c456dac81600d97"
   integrity sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==
+
+"@rails/actioncable@>=7.0":
+  version "7.2.302"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.302.tgz#f074632ee55aa1b5b16cd2be094b42981a71c322"
+  integrity sha512-9JOPzUb7RCqIEWeoE78mPFd71fzyJ25LjeMzD45zQ75f41ca7BsgQVqiyrIuxDZ1yyZ4PdyxCMZF0KJlJ9qX0g==
 
 "@rolldown/binding-android-arm64@1.0.3":
   version "1.0.3"
@@ -2307,7 +2330,7 @@ side-channel@^1.1.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-stimulus-vite-helpers@^3.0.0:
+stimulus-vite-helpers@^3.0.0, stimulus-vite-helpers@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/stimulus-vite-helpers/-/stimulus-vite-helpers-3.1.0.tgz#9216d703ac8d74befece4499ea738c18de408842"
   integrity sha512-qy9vnNnu6e/1PArEndp456BuSKLQkBgc+vX2pedOHT0N4GSLQY0l5fuQ4ft56xZ8xSWqrfuYSR+GXXIPtoESww==


### PR DESCRIPTION
This is a more lightweight alternative to #168 which keeps the old pages where they are by simply integrating the react pages into turbo navigation. That way future PRs can introduce server-side rendered pages one by one without rewriting everything at the same time.

UX wise this is a slight temporary regression (react remounts on every navigation, causing a tiny flicker) which will improve once we have server-rendered components instead.